### PR TITLE
Minor grammar fix in events example footer

### DIFF
--- a/config/site.js
+++ b/config/site.js
@@ -1,4 +1,4 @@
 module.exports = {
   appName: 'We.js events',
-  appFooterText: 'Build with <a href="http://wejs.org" target="_blanck">We.js</a>'
+  appFooterText: 'Built with <a href="http://wejs.org" target="_blanck">We.js</a>'
 };


### PR DESCRIPTION
 "Build with We.js" to "Built with We.js"
