### PR TITLE
Add link to We.js Heroku docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ config/local.js files are loaded after all files and can override other configs
 
 TODO, Looking for contributors!
 
+## Deployment
+### Heroku 
+* See https://wejs.org/docs/we/heroku
+
 ## License
 
 under the MIT license.


### PR DESCRIPTION
I was struggling with configuring for Heroku deployment so I think it might help others to have a link to the We.js Heroku deploy doc.

Thanks!
- Elijah
